### PR TITLE
ユーザー取得周りの見直し

### DIFF
--- a/app/entities/user.go
+++ b/app/entities/user.go
@@ -16,6 +16,8 @@ type UserEntity struct {
 func (e *UserEntity) ConvertUser(m *models.User) {
 	e.UserID = m.ID
 	e.LoginID = m.LoginID
+	e.Name = m.Name.String
+	e.Mail = m.Mail.String
 }
 
 func (e *UserEntity) ConvertUserModel() models.User {

--- a/app/repositories/ri/UserRepository.go
+++ b/app/repositories/ri/UserRepository.go
@@ -3,6 +3,6 @@ package ri
 import "app/entities"
 
 type UserRepository interface {
-	GetUser(loginID string) (*entities.UserEntity, error)
+	GetUser(loginID, name, mail *string) ([]*entities.UserEntity, error)
 	RegistUser(user entities.UserEntity) error
 }

--- a/app/repositories/rmock/userRepositoryMock.go
+++ b/app/repositories/rmock/userRepositoryMock.go
@@ -9,9 +9,9 @@ type UserRepositoryMock struct {
 	mock.Mock
 }
 
-func (_m *UserRepositoryMock) GetUser(loginID string) (*entities.UserEntity, error) {
-	ret := _m.Called(loginID)
-	return ret.Get(0).(*entities.UserEntity), ret.Error(1)
+func (_m *UserRepositoryMock) GetUser(loginID, name, mail *string) ([]*entities.UserEntity, error) {
+	ret := _m.Called(loginID, name, mail)
+	return ret.Get(0).([]*entities.UserEntity), ret.Error(1)
 }
 
 func (_m *UserRepositoryMock) RegistUser(user entities.UserEntity) error {

--- a/app/repositories/userRepositoryImp_test.go
+++ b/app/repositories/userRepositoryImp_test.go
@@ -22,18 +22,39 @@ func (s *GetUserSuite) SetupSuite() {
 	s.repo = repositories.NewUserRepository(conn)
 }
 
-func (s *GetUserSuite) TestSuccess() {
-	u, err := s.repo.GetUser("test")
+func (s *GetUserSuite) TestSuccessALL() {
+	ul, err := s.repo.GetUser(nil, nil, nil)
 
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), u.LoginID, "test")
+	assert.Equal(s.T(), ul[0].LoginID, "test")
+	assert.Equal(s.T(), ul[0].Name, "test")
 }
 
-func (s *GetUserSuite) TestFailNoUser() {
-	u, err := s.repo.GetUser("")
+func (s *GetUserSuite) TestSuccessLoginID() {
+	loginID := "test"
+	ul, err := s.repo.GetUser(&loginID, nil, nil)
 
 	assert.Nil(s.T(), err)
-	assert.Nil(s.T(), u)
+	assert.Equal(s.T(), ul[0].LoginID, "test")
+	assert.Equal(s.T(), ul[0].Name, "test")
+}
+
+func (s *GetUserSuite) TestSuccessName() {
+	name := "test"
+	ul, err := s.repo.GetUser(nil, &name, nil)
+
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), ul[0].LoginID, "test")
+	assert.Equal(s.T(), ul[0].Name, "test")
+}
+
+func (s *GetUserSuite) TestSuccessMail() {
+	mail := "test@test"
+	ul, err := s.repo.GetUser(nil, nil, &mail)
+
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), ul[0].LoginID, "test")
+	assert.Equal(s.T(), ul[0].Name, "test")
 }
 
 func TestGetUserSuite(t *testing.T) {

--- a/app/usecases/loginUsecaseImp.go
+++ b/app/usecases/loginUsecaseImp.go
@@ -33,18 +33,18 @@ func (u *loginUsecaseImp) Validate(param rqp.Login) error {
 }
 
 func (u *loginUsecaseImp) GetUser(loginID string) (*entities.UserEntity, error) {
-	user, err := u.ur.GetUser(loginID)
+	user, err := u.ur.GetUser(&loginID, nil, nil)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if user == nil {
+	if len(user) != 1 {
 		err = fmt.Errorf("対象ユーザがみつかりませんでした")
 		return nil, err
 	}
 
-	return user, nil
+	return user[0], nil
 }
 
 func (u *loginUsecaseImp) GetToken(user *entities.UserEntity) (*entities.TokenEntity, error) {

--- a/app/usecases/loginUsecaseImp_test.go
+++ b/app/usecases/loginUsecaseImp_test.go
@@ -71,7 +71,12 @@ func (s *GetUserLoginUsecaseSuite) SetupSuite() {
 
 func (s *GetUserLoginUsecaseSuite) TestSuccess() {
 	user := entities.UserEntity{UserID: 1, LoginID: "t1"}
-	s.urepo.On("GetUser", "t1").Return(&user, nil)
+	loginID := "t1"
+	var name, mail *string
+	var ul []*entities.UserEntity
+	ul = append(ul, &user)
+
+	s.urepo.On("GetUser", &loginID, name, mail).Return(ul, nil)
 
 	repo := ri.InRepository{UserRepo: s.urepo}
 
@@ -85,8 +90,13 @@ func (s *GetUserLoginUsecaseSuite) TestSuccess() {
 }
 
 func (s *GetUserLoginUsecaseSuite) TestError() {
-	user := entities.UserEntity{UserID: 1, LoginID: "t1"}
-	s.urepo.On("GetUser", "t2").Return(&user, fmt.Errorf("error test"))
+	user := entities.UserEntity{UserID: 1, LoginID: "t2"}
+	loginID := "t2"
+	var name, mail *string
+	var ul []*entities.UserEntity
+	ul = append(ul, &user)
+
+	s.urepo.On("GetUser", &loginID, name, mail).Return(ul, fmt.Errorf("error test"))
 
 	repo := ri.InRepository{UserRepo: s.urepo}
 

--- a/app/usecases/userUsecaseImp.go
+++ b/app/usecases/userUsecaseImp.go
@@ -31,13 +31,19 @@ func (uc *userUsecaseImp) RegistValidate(param rqp.RegistUser) error {
 }
 
 func (uc *userUsecaseImp) CheckUser(loginID string) (*entities.UserEntity, error) {
-	um, err := uc.uRepo.GetUser(loginID)
+	um, err := uc.uRepo.GetUser(&loginID, nil, nil)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return um, nil
+	if len(um) != 1 {
+		err = fmt.Errorf(fmt.Sprintf("ユーザーが見つかりませんでいた。 該当数:%d", len(um)))
+		logger.Error(err.Error())
+		return nil, err
+	}
+
+	return um[0], nil
 }
 
 func (uc *userUsecaseImp) RegistUser(user *entities.UserEntity) error {

--- a/app/usecases/userUsecaseImp_test.go
+++ b/app/usecases/userUsecaseImp_test.go
@@ -1,6 +1,7 @@
 package usecases_test
 
 import (
+	"app/controllers/rqp"
 	"app/entities"
 	"app/repositories/ri"
 	"app/repositories/rmock"
@@ -44,6 +45,130 @@ func (s *RegistUserUsecaseSuite) TestFailed() {
 	assert.Equal(s.T(), err.Error(), "error test")
 }
 
-func TestVRegistUserUsecaseSuite(t *testing.T) {
+func TestRegistUserUsecaseSuite(t *testing.T) {
 	suite.Run(t, new(RegistUserUsecaseSuite))
+}
+
+type CheckUserUsecaseSuite struct {
+	suite.Suite
+	urepo *rmock.UserRepositoryMock
+}
+
+func (s *CheckUserUsecaseSuite) SetupSuite() {
+	s.urepo = new(rmock.UserRepositoryMock)
+}
+
+func (s *CheckUserUsecaseSuite) TestSuccess() {
+	loginID := "test"
+	var name, mail *string
+	var ul []*entities.UserEntity
+	u := entities.UserEntity{UserID: 1}
+	ul = append(ul, &u)
+	s.urepo.On("GetUser", &loginID, name, mail).Return(ul, nil)
+
+	ir := ri.InRepository{UserRepo: s.urepo}
+	uc := usecases.NewUserUsecase(ir)
+
+	user, err := uc.CheckUser(loginID)
+
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), user.UserID, 1)
+}
+
+func (s *CheckUserUsecaseSuite) TestSFailedError() {
+	loginID := "test2"
+	var name, mail *string
+	var ul []*entities.UserEntity
+	s.urepo.On("GetUser", &loginID, name, mail).Return(ul, fmt.Errorf("test error"))
+
+	ir := ri.InRepository{UserRepo: s.urepo}
+	uc := usecases.NewUserUsecase(ir)
+
+	user, err := uc.CheckUser(loginID)
+
+	assert.Equal(s.T(), err.Error(), "test error")
+	assert.Nil(s.T(), user)
+}
+
+func (s *CheckUserUsecaseSuite) TestSFailedUnique() {
+	loginID := "test3"
+	var name, mail *string
+	var ul []*entities.UserEntity
+	u := entities.UserEntity{UserID: 1}
+	ul = append(ul, &u)
+	u = entities.UserEntity{UserID: 2}
+	ul = append(ul, &u)
+	s.urepo.On("GetUser", &loginID, name, mail).Return(ul, nil)
+
+	ir := ri.InRepository{UserRepo: s.urepo}
+	uc := usecases.NewUserUsecase(ir)
+
+	user, err := uc.CheckUser(loginID)
+
+	assert.Equal(s.T(), err.Error(), "ユーザーが見つかりませんでいた。 該当数:2")
+	assert.Nil(s.T(), user)
+}
+
+func TestCheckUserUsecaseSuite(t *testing.T) {
+	suite.Run(t, new(CheckUserUsecaseSuite))
+}
+
+type RegistValidateUsecaseSuite struct {
+	suite.Suite
+	urepo *rmock.UserRepositoryMock
+}
+
+func (s *RegistValidateUsecaseSuite) SetupSuite() {
+	s.urepo = new(rmock.UserRepositoryMock)
+}
+
+func (s *RegistValidateUsecaseSuite) TestSuccess() {
+	ir := ri.InRepository{UserRepo: s.urepo}
+	uc := usecases.NewUserUsecase(ir)
+
+	param := rqp.RegistUser{LoginID: "test", Name: "test2", Password: "testtest"}
+
+	err := uc.RegistValidate(param)
+
+	assert.Nil(s.T(), err)
+}
+
+func (s *RegistValidateUsecaseSuite) TestFailedNoLoginID() {
+	ir := ri.InRepository{UserRepo: s.urepo}
+	uc := usecases.NewUserUsecase(ir)
+
+	param := rqp.RegistUser{Name: "test2", Password: "testtest"}
+
+	err := uc.RegistValidate(param)
+
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), err.Error(), "必須項目が未設定")
+}
+
+func (s *RegistValidateUsecaseSuite) TestFailedNoName() {
+	ir := ri.InRepository{UserRepo: s.urepo}
+	uc := usecases.NewUserUsecase(ir)
+
+	param := rqp.RegistUser{LoginID: "test2", Password: "testtest"}
+
+	err := uc.RegistValidate(param)
+
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), err.Error(), "必須項目が未設定")
+}
+
+func (s *RegistValidateUsecaseSuite) TestFailedNoPassword() {
+	ir := ri.InRepository{UserRepo: s.urepo}
+	uc := usecases.NewUserUsecase(ir)
+
+	param := rqp.RegistUser{LoginID: "test2", Name: "testtest"}
+
+	err := uc.RegistValidate(param)
+
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), err.Error(), "必須項目が未設定")
+}
+
+func TestRegistValidateUsecaseSuite(t *testing.T) {
+	suite.Run(t, new(RegistValidateUsecaseSuite))
 }


### PR DESCRIPTION
## 概要
User情報処理を複数用意してしまうので、
Repository側は取得のみに修正
Usecase側で必要な判定ロジックを用意するようにした

## 変更点


## 影響範囲


## テスト
修正後に全テストが実行可能であることを確認済み

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #123